### PR TITLE
Use 'not_null' pointers to harden code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ endif (WS_PARALLEL)
 add_subdirectory(${workspace_SOURCE_DIR}/external/yaml-cpp)
 add_subdirectory(${workspace_SOURCE_DIR}/external/rapidyaml ryml)
 add_subdirectory(${workspace_SOURCE_DIR}/external/fmt)
+add_subdirectory(${workspace_SOURCE_DIR}/external/GSL)
 
 get_directory_property(LINKER_VAR LINK_DIRECTORIES)
 message(STATUS "LINKER_VAR: ${LINKER_VAR}")
@@ -124,7 +125,14 @@ ADD_LIBRARY(ws_common OBJECT
 	${workspace_SOURCE_DIR}/src/caps.cpp
 	)
 
-TARGET_LINK_LIBRARIES(ws_common PUBLIC yaml-cpp::yaml-cpp fmt::fmt ryml::ryml)
+target_link_libraries(ws_common
+    PUBLIC
+        fmt::fmt
+        ryml::ryml
+        yaml-cpp::yaml-cpp
+    PRIVATE
+        Microsoft.GSL::GSL
+)
 
 ADD_EXECUTABLE( ws_list ${workspace_SOURCE_DIR}/src/ws_list.cpp )
 TARGET_LINK_LIBRARIES( ws_list "-L${LINKER_VAR}" ws_common ${Boost_LIBRARIES} ${EXTRA_STATIC_LIBS} ${LIBCAP} fmt::fmt ${PARLIB})

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ yaml-cpp (to be removed)
 rapidyaml
 boost program_options + boost system
 Catch2 (if tests are used)
+Guidelines Support Library (GSL)
 
 ## Status
 

--- a/external/get_externals.sh
+++ b/external/get_externals.sh
@@ -2,3 +2,4 @@ git clone https://github.com/catchorg/Catch2.git
 git clone https://github.com/fmtlib/fmt.git
 git clone https://github.com/jbeder/yaml-cpp.git
 git clone --recursive https://github.com/biojppm/rapidyaml.git
+git clone https://github.com/microsoft/GSL.git


### PR DESCRIPTION
We are using frequently a frunction returning a pointer to a struct and then access data elements from this scruct via pointer dereferencing. Instead of always having to check for the pointer to be not the nullptr in or code before dereferencing, use 'not_null' pointers from the Guidelines Support Library (GSL). For more information see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-nullptr