### PR TITLE
Cmake build system update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
+if(CMAKE_VERSION GREATER_EQUAL 3.30)
+    cmake_policy(SET CMP0167 NEW) # prefer cmake configuration provided by the boost package itself
+endif()
 
 project(workspace
     VERSION 2.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,16 +123,11 @@ TARGET_LINK_LIBRARIES( ws_allocate "-L${LINKER_VAR}" ws_common ${Boost_LIBRARIES
 
 
 
-
-
 if(BUILD_TESTS)
-	ADD_SUBDIRECTORY(${workspace_SOURCE_DIR}/external/Catch2)
-	#find_package(Catch2 REQUIRED)
-	#add_executable(config_test tests/config_test.cpp src/config.cpp src/utils.cpp src/dbv1.cpp src/capability.cpp)
-	add_executable(config_test tests/config_test.cpp src/config.cpp src/config.h src/utils.h src/utils.cpp src/dbv1.cpp src/dbv1.h src/capability.cpp)
-	target_link_libraries(config_test PRIVATE  Catch2::Catch2WithMain yaml-cpp::yaml-cpp fmt::fmt ryml::ryml c4core::c4core ${PARLIB})
+    add_subdirectory(${workspace_SOURCE_DIR}/external/Catch2)
 
-	include(CTest)
-	include(Catch)
-	catch_discover_tests(config_test)
-ENDIF (BUILD_TESTS)
+    include(CTest)
+    include(Catch)
+
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,20 @@ project(workspace
 # set to version number of the latest release
 add_definitions("-DWS_VERSION=\"${workspace_VERSION}\"")
 
-message(STATUS "build type: " ${CMAKE_BUILD_TYPE})
-message(STATUS "use cmake -DCMAKE_BUILD_TYPE=debug for debug build")
+if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
+    add_definitions(-DIS_GIT_REPOSITORY)
+    # git commit hash macro
+    execute_process(
+        COMMAND git log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
+endif()
+
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "Use cmake -DCMAKE_BUILD_TYPE=Release for release build")
 
 add_compile_options(-Wall -Wextra)
 add_link_options($<$<CONFIG:Release>:-s>)
@@ -89,18 +101,6 @@ add_subdirectory(${workspace_SOURCE_DIR}/external/GSL)
 
 get_directory_property(LINKER_VAR LINK_DIRECTORIES)
 message(STATUS "LINKER_VAR: ${LINKER_VAR}")
-
-IF (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
-    add_definitions(-DIS_GIT_REPOSITORY)
-    # git commit hash macro
-    execute_process(
-       COMMAND git log -1 --format=%h
-       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-       OUTPUT_VARIABLE GIT_COMMIT_HASH
-       OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
-ENDIF ()
 
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 if(CMAKE_VERSION GREATER_EQUAL 3.30)
     cmake_policy(SET CMP0167 NEW) # prefer cmake configuration provided by the boost package itself
 endif()
+if(CMAKE_VERSION GREATER_EQUAL 3.31)
+    cmake_policy(SET CMP0177 NEW) # normalize all install DESTINATION values except for INCLUDES DESTINATION
+endif()
 
 project(workspace
     VERSION 2.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,16 +75,6 @@ ELSE (TERMINFO)
 ENDIF (TERMINFO)
 
 
-# find termcap for "are you human" checker
-#FIND_LIBRARY(TERMCAP NAMES libtermcap.so libtermcap.a)
-#IF (TERMCAP)
-    #MESSAGE("-- Found termcap")
-    #INCLUDE_DIRECTORIES(${TERMCAP_INCLUDE_DIRS})
-    #SET(LIBS ${LIBS} ${TERMCAP_LIBRARIES})
-#ELSE (TERMCAP)
-    #MESSAGE(FATAL_ERROR "-- No termcap, please get a termcap library!")
-#ENDIF (TERMCAP)
-
 OPTION(WS_PARALLEL "std::par usage, needs TBB" FALSE)
 if (WS_PARALLEL)
     find_package(TBB REQUIRED tbb)
@@ -147,22 +137,6 @@ TARGET_LINK_LIBRARIES( ws_allocate "-L${LINKER_VAR}" ws_common ${Boost_LIBRARIES
 
 
 
-# Get install target
-#set(PROGRAM_PERMISSIONS_DEFAULT
-#    OWNER_WRITE OWNER_READ OWNER_EXECUTE
-#    GROUP_READ GROUP_EXECUTE
-#    WORLD_READ WORLD_EXECUTE)
-#install (FILES bin/ws_extend bin/ws_find bin/ws_list bin/ws_register bin/ws_send_ical DESTINATION bin PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT})
-#install(TARGETS
-#      ws_allocate ws_release ws_restore
-#      DESTINATION bin
-#      PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT} SETUID)
-#install (FILES sbin/ws_expirer sbin/ws_restore sbin/ws_validate_config DESTINATION sbin PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT})
-#
-## Install man pages
-#INSTALL(FILES man/ws_allocate.1 man/ws_find.1 man/ws_register.1
-#              man/ws_restore.1 man/ws_extend.1 man/ws_list.1 man/ws_release.1
-#              man/ws_send_ical.1             DESTINATION share/man/man1)
 
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,21 +34,20 @@ add_link_options($<$<CONFIG:Release>:-s>)
 add_link_options($<$<CONFIG:MinSizeRel>:-s>)
 
 
+option(WS_ALLOW_USER_DEBUG "allow users to enable debugging and tracing" FALSE)
+if(WS_ALLOW_USER_DEBUG)
+    add_definitions("-DWS_ALLOW_USER_DEBUG")
+endif()
 
-OPTION(WS_ALLOW_USER_DEBUG "allow users to enable debugging and tracing" FALSE)
-IF (WS_ALLOW_USER_DEBUG)
-    ADD_DEFINITIONS("-DWS_ALLOW_USER_DEBUG")
-ENDIF (WS_ALLOW_USER_DEBUG)
 
-
-FIND_LIBRARY(HAVECAP NAMES libcap.a libcap.so)
-IF (HAVECAP)
-    MESSAGE("-- Found libcap")
-	ADD_DEFINITIONS("-DWS_CAPA")
-	SET(LIBCAP "cap")
-ELSE (HAVECAP)
-	SET(LIBCAP "")
-ENDIF (HAVECAP)
+find_library(LIBCAP NAMES libcap.a libcap.so)
+if(LIBCAP)
+    message(STATUS "Found libcap (${LIBCAP}). Building with capability support.")
+    add_compile_definitions("-DWS_CAPA")
+else()
+    message(WARNING "No libcap found on the system. Falling back to SUID.")
+    set(LIBCAP "")
+endif()
 
 
 list(APPEND BOOST_COMPONENTS system program_options)
@@ -56,71 +55,38 @@ find_package(Boost COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 
 
 # find terminfo for "are you human" checker
-FIND_LIBRARY(TERMINFO NAMES libtinfo.so libtinfo.a)
-IF (TERMINFO)
-    MESSAGE("-- Found terminfo")
-    INCLUDE_DIRECTORIES(${TERMINFO_INCLUDE_DIRS})
-    SET(LIBS ${LIBS} ${TERMINFO_LIBRARIES})
-    SET(TLIB "tinfo")
-ELSE (TERMINFO)
-    MESSAGE("-- No terminfo, trying curses")
-    #find curses for terminfo for "are you human" checker
-    SET(CURSES_NEED_NCURSES TRUE)
+find_library(LIBTINFO NAMES libtinfo.so libtinfo.a)
+if(LIBTINFO)
+    message(STATUS "Found libtinfo")
+else()
+    message(WARNING "No libtinfo found, trying curses alternative ...")
+    set(CURSES_NEED_NCURSES TRUE)
     find_package(Curses REQUIRED)
     include_directories(${CURSES_INCLUDE_DIR})
     link_directories(${CURSES_LIBRARY_DIR})
-    SET(TLIB ${CURSES_LIBRARIES})
-ENDIF (TERMINFO)
+    set(LIBTINFO ${CURSES_LIBRARIES})
+endif()
 
 
-OPTION(WS_PARALLEL "std::par usage, needs TBB" FALSE)
-if (WS_PARALLEL)
+option(WS_PARALLEL "std::par usage, needs TBB" FALSE)
+if(WS_PARALLEL)
     find_package(TBB REQUIRED tbb)
-    ADD_DEFINITIONS("-DPARALLEL")
-    SET(PARLIB "TBB::tbb")
-else (WS_PARALLEL)
-    SET(PARLIB "")
-endif (WS_PARALLEL)
+    add_definitions("-DPARALLEL")
+    set(PARLIB "TBB::tbb")
+else()
+    set(PARLIB "")
+endif()
+
 
 add_subdirectory(${workspace_SOURCE_DIR}/external/yaml-cpp)
 add_subdirectory(${workspace_SOURCE_DIR}/external/rapidyaml ryml)
 add_subdirectory(${workspace_SOURCE_DIR}/external/fmt)
 add_subdirectory(${workspace_SOURCE_DIR}/external/GSL)
 
-get_directory_property(LINKER_VAR LINK_DIRECTORIES)
-message(STATUS "LINKER_VAR: ${LINKER_VAR}")
 
-SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
 
-ADD_LIBRARY(ws_common OBJECT 
-	${workspace_SOURCE_DIR}/src/db.h
-	${workspace_SOURCE_DIR}/src/dbv1.cpp 
-	${workspace_SOURCE_DIR}/src/dbv1.h 
-	${workspace_SOURCE_DIR}/src/utils.h
-	${workspace_SOURCE_DIR}/src/utils.cpp 
-	${workspace_SOURCE_DIR}/src/user.h
-	${workspace_SOURCE_DIR}/src/user.cpp 
-	${workspace_SOURCE_DIR}/src/config.h
-	${workspace_SOURCE_DIR}/src/config.cpp
-	${workspace_SOURCE_DIR}/src/caps.h
-	${workspace_SOURCE_DIR}/src/caps.cpp
-	)
-
-target_link_libraries(ws_common
-    PUBLIC
-        fmt::fmt
-        ryml::ryml
-        yaml-cpp::yaml-cpp
-    PRIVATE
-        Microsoft.GSL::GSL
-)
-
-ADD_EXECUTABLE( ws_list ${workspace_SOURCE_DIR}/src/ws_list.cpp )
-TARGET_LINK_LIBRARIES( ws_list "-L${LINKER_VAR}" ws_common ${Boost_LIBRARIES} ${EXTRA_STATIC_LIBS} ${LIBCAP} fmt::fmt ${PARLIB})
-
-ADD_EXECUTABLE( ws_allocate ${workspace_SOURCE_DIR}/src/ws_allocate.cpp )
-TARGET_LINK_LIBRARIES( ws_allocate "-L${LINKER_VAR}" ws_common ${Boost_LIBRARIES} ${EXTRA_STATIC_LIBS} ${LIBCAP} fmt::fmt ${PARLIB})
-
+add_subdirectory(src)
 
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,18 +35,6 @@ add_link_options($<$<CONFIG:MinSizeRel>:-s>)
 
 
 
-OPTION(WS_STATIC "static linking" FALSE)
-IF (WS_STATIC)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
-    set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
-    SET(EXTRA_STATIC_LIBS "pthread")
-#    set(Boost_USE_STATIC_LIBS ON)
-#    set(Boost_USE_STATIC_RUNTIME ON) 
-ELSE (WS_STATIC)
-    set(Boost_USE_STATIC_LIBS OFF)
-    set(Boost_USE_STATIC_RUNTIME OFF) 
-ENDIF (WS_STATIC)
-
 OPTION(WS_ALLOW_USER_DEBUG "allow users to enable debugging and tracing" FALSE)
 IF (WS_ALLOW_USER_DEBUG)
     ADD_DEFINITIONS("-DWS_ALLOW_USER_DEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,10 @@ add_definitions("-DWS_VERSION=\"${workspace_VERSION}\"")
 message(STATUS "build type: " ${CMAKE_BUILD_TYPE})
 message(STATUS "use cmake -DCMAKE_BUILD_TYPE=debug for debug build")
 
+add_compile_options(-Wall -Wextra)
 add_link_options($<$<CONFIG:Release>:-s>)
 add_link_options($<$<CONFIG:MinSizeRel>:-s>)
 
-SET(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 ")
-SET(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -g -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 -fstack-protector-all -fcf-protection=full  -fsanitize=address -D_GLIBCXX_ASSERTIONS")
-SET(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 ")
 
 
 OPTION(WS_STATIC "static linking" FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ add_definitions("-DWS_VERSION=\"${workspace_VERSION}\"")
 message(STATUS "build type: " ${CMAKE_BUILD_TYPE})
 message(STATUS "use cmake -DCMAKE_BUILD_TYPE=debug for debug build")
 
+add_link_options($<$<CONFIG:Release>:-s>)
+add_link_options($<$<CONFIG:MinSizeRel>:-s>)
+
 SET(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 ")
 SET(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -g -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 -fstack-protector-all -fcf-protection=full  -fsanitize=address -D_GLIBCXX_ASSERTIONS")
 SET(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++17 -Os -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 ")
@@ -106,10 +109,6 @@ IF (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
 ENDIF ()
 
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
-
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
-
 
 ADD_LIBRARY(ws_common OBJECT 
 	${workspace_SOURCE_DIR}/src/db.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_library(ws_common
+    caps.cpp
+    caps.h
+    config.cpp
+    config.h
+    db.h
+    dbv1.cpp
+    dbv1.h
+    user.cpp
+    user.h
+    utils.cpp
+    utils.h
+)
+
+target_link_libraries(ws_common
+    PUBLIC
+        fmt::fmt
+        ryml::ryml
+        yaml-cpp::yaml-cpp
+        ${LIBCAP}
+        ${LIBTINFO}
+        ${PARLIB}
+    PRIVATE
+        Microsoft.GSL::GSL
+)
+
+add_executable(ws_list
+    ws_list.cpp
+)
+target_link_libraries(ws_list
+    PRIVATE
+        ws_common
+        ${Boost_LIBRARIES}
+        fmt::fmt
+)
+
+add_executable(ws_allocate
+    ws_allocate.cpp
+)
+target_link_libraries(ws_allocate
+    PRIVATE
+        ws_common
+        ${Boost_LIBRARIES}
+        fmt::fmt
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(config_test
+    config_test.cpp
+)
+target_link_libraries(config_test
+    PRIVATE
+        ws_common
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(config_test)


### PR DESCRIPTION
Rewrite and restructuring of the CMake build system using the "new cmake way" with target-based build configurations and subdirectories.

External dependencies are still handled via manual download (using external/get_externals.sh) and subdirectory includes in our cmake configuration.