### PR TITLE
Some initial e2e cli tests suing bats

### DIFF
--- a/bats/test/test_helper/common-setup.bash
+++ b/bats/test/test_helper/common-setup.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+_common_setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+
+    # get the containing directory of this file
+    # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+    # as those will point to the bats executable's location or the preprocessed file respectively
+    PROJECT_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/.." >/dev/null 2>&1 && pwd )"
+    # make executables in src/ visible to PATH
+    PATH="$PROJECT_ROOT/../build/debug/bin/:$PATH"
+}

--- a/bats/test/ws_allocate.bats
+++ b/bats/test/ws_allocate.bats
@@ -1,0 +1,16 @@
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "ws_allocate present" {
+    which ws_allocate
+}
+@test "ws_allocate print version" {
+    run ws_allocate --version
+    assert_output --partial "workspace"
+}
+@test "ws_allocate print help" {
+    run ws_allocate --help
+    assert_output --partial "Usage"
+}

--- a/bats/test/ws_list.bats
+++ b/bats/test/ws_list.bats
@@ -1,0 +1,16 @@
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "ws_list present" {
+    which ws_list
+}
+@test "ws_list print version" {
+    run ws_list --version
+    assert_output --partial "workspace"
+}
+@test "ws_list print help" {
+    run ws_list --help
+    assert_output --partial "Usage"
+}


### PR DESCRIPTION
Add setup for e2e cli testing with bats (https://bats-core.readthedocs.io/)
- common setup expects a cmake build director 'build/debug/' when setting the PATH variable for the moment. Note: You can run cmake with
  > cmake -B build/debug/ .
  > cmake --build build/debug/

  to specify this build directory for the configure and build step.
- initial basic tests for ws_list and ws_allocate checking for program to exist and provide output when called with the --version and --help option.