### PR TITLE
Add C++17 as a compile feature for the ws_common library target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(ws_common
     utils.cpp
     utils.h
 )
+target_compile_features(ws_common PUBLIC cxx_std_17)
 
 target_link_libraries(ws_common
     PUBLIC


### PR DESCRIPTION
On systems with older gcc versions (gcc 8.5) it is necessary to ensure the C++17 support in cmake. Adding this to the ws_common library target as PUBLIC feature will propagte it to consumers of the target, i.e., targets that include ws_common in their target_link command.