### PR TITLE
Caps fixes

### DIFF
--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -9,6 +9,7 @@
  *  a workspace is a temporary directory created in behalf of a user with a limited lifetime.
  *
  *  (c) Holger Berger 2021,2023,2024
+ *  (c) Christoph Niethammer 2024
  * 
  *  hpc-workspace-v2 is based on workspace by Holger Berger, Thomas Beisel and Martin Hecht
  *
@@ -58,7 +59,8 @@ Cap::Cap() {
     cap_t caps, oldcaps;
     cap_value_t cap_list[1];
 
-    oldcaps = caps = cap_get_proc();
+    caps = cap_get_proc();
+    oldcaps = cap_dup(caps);
 
     cap_list[0] = CAP_DAC_OVERRIDE;  // this has to be set for all executables using this!
 
@@ -73,6 +75,7 @@ Cap::Cap() {
     }
 
     cap_free(caps);
+    cap_free(oldcaps);
 #endif
 
     if (!issetuid && !hascaps) isusermode = true;

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -96,7 +96,7 @@ void Cap::drop_caps(std::vector<cap_value_t> cap_arg, int uid, utils::SrcPos src
 #ifdef WS_CAPA
     if(hascaps) {
         cap_t caps;
-        cap_value_t cap_list[1];
+        cap_value_t cap_list[cap_arg.size()];
 
         int arg=0;
         for(const auto &ca: cap_arg) {

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -28,7 +28,7 @@
  */
 
 
-#include <stdlib.h>
+#include <cstdlib>
 
 
 #include "fmt/base.h"

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -115,7 +115,9 @@ void Cap::drop_caps(std::vector<cap_value_t> cap_arg, int uid, utils::SrcPos src
         if (cap_set_proc(caps) != 0) {
             fmt::print(stderr, "Error  : problem dropping capabilities.\n");
             cap_t cap = cap_get_proc();
-            fmt::print(stderr, "Info   : running with capabilities: {}\n", cap_to_text(cap, NULL));
+            char * cap_text = cap_to_text(cap, NULL);
+            fmt::print(stderr, "Info   : running with capabilities: {}\n", cap_text);
+            cap_free(cap_text);
             cap_free(cap);
             cap_free(caps);
             exit(1);

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -132,7 +132,7 @@ void Cap::drop_caps(std::vector<cap_value_t> cap_arg, int uid, utils::SrcPos src
 }
 
 // remove a capability from the effective set
-void Cap::lower_cap(int cap, int dbuid, utils::SrcPos srcpos)
+void Cap::lower_cap(cap_value_t cap, int dbuid, utils::SrcPos srcpos)
 {
 #ifdef WS_CAPA
     if(hascaps) {   

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -49,7 +49,8 @@ Cap::Cap() {
         // traceflag = true;
     if (traceflag) fmt::println(stderr, "Trace  : Cap::Cap()");
     if (debugflag) fmt::println(stderr, "euid={}, uid={}", geteuid(), getuid());
-    if (user::isSetuid()) issetuid = true; else issetuid = false;
+
+    issetuid = user::isSetuid();
     hascaps = false;
     isusermode = false;
 

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -66,6 +66,8 @@ Cap::Cap() {
 
     if (cap_set_flag(caps, CAP_EFFECTIVE, 1, cap_list, CAP_SET) == -1) {
         fmt::print(stderr, "Error  : problem with capabilities, should not happen\n");
+        cap_free(caps);
+        cap_free(oldcaps);
         exit(1);
     }
 
@@ -115,6 +117,7 @@ void Cap::drop_caps(std::vector<cap_value_t> cap_arg, int uid, utils::SrcPos src
             cap_t cap = cap_get_proc();
             fmt::print(stderr, "Info   : running with capabilities: {}\n", cap_to_text(cap, NULL));
             cap_free(cap);
+            cap_free(caps);
             exit(1);
         }
 

--- a/src/caps.cpp
+++ b/src/caps.cpp
@@ -69,7 +69,7 @@ Cap::Cap() {
         exit(1);
     }
 
-    if (cap_set_proc(caps) != -1) {
+    if (cap_set_proc(caps) == 0) {
         hascaps = true;
         cap_set_proc(oldcaps);
     }
@@ -110,7 +110,7 @@ void Cap::drop_caps(std::vector<cap_value_t> cap_arg, int uid, utils::SrcPos src
             exit(1);
         }
 
-        if (cap_set_proc(caps) == -1) {
+        if (cap_set_proc(caps) != 0) {
             fmt::print(stderr, "Error  : problem dropping capabilities.\n");
             cap_t cap = cap_get_proc();
             fmt::print(stderr, "Info   : running with capabilities: {}\n", cap_to_text(cap, NULL));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,5 +6,15 @@ target_link_libraries(config_test
         ws_common
         Catch2::Catch2WithMain
 )
-
 catch_discover_tests(config_test)
+
+
+add_executable(caps_test
+    caps_test.cpp
+)
+target_link_libraries(caps_test
+    PRIVATE
+        ws_common
+        Catch2::Catch2WithMain
+)
+catch_discover_tests(caps_test)

--- a/tests/caps_test.cpp
+++ b/tests/caps_test.cpp
@@ -1,0 +1,27 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include <catch2/catch_test_macros.hpp>
+
+
+#include "../src/caps.h"
+
+#include <sys/capability.h>
+
+
+bool debugflag = false;
+bool traceflag = false;
+
+TEST_CASE( "Caps", "[capabilities]" ) {
+
+  Cap caps{}; // default constructor without arguments
+
+  SECTION("check interfaces are present and callable") {
+    bool issetuid = caps.isSetuid(); // isSetuid()
+    bool hascaps = caps.hasCaps(); // hasCaps()
+    bool isusermode = caps.isUserMode(); // isUserMode()
+  }
+
+  SECTION("check cap drop is present and callable") {
+    caps.drop_caps({CAP_DAC_OVERRIDE, CAP_CHOWN, CAP_FOWNER}, getuid(), utils::SrcPos(__FILE__, __LINE__, __func__));
+  }
+
+}


### PR DESCRIPTION
A bunch of fixes for caps (capability) code including:
* buffer overflow
* various memory leaks
* safer return/error code checks
* fix for broken cap reset in caps constructor
* added a very basic test for the caps class.

Note: The test still reports a memory leak. This seems to be related to the cap_set_proc call but cannot be identified with anything in the caps or caps_test code. Seems to be an issue with libcap...