### PR TITLE
Make only partial clones of external library sources

### DIFF
--- a/external/get_externals.sh
+++ b/external/get_externals.sh
@@ -6,7 +6,7 @@ OPWD=$PWD
 echo Catch2
 if [ ! -d Catch2 ]
 then
-	git clone https://github.com/catchorg/Catch2.git
+	git clone --filter=tree:0 https://github.com/catchorg/Catch2.git
 else 
 	cd Catch2
 	git pull
@@ -15,7 +15,7 @@ fi
 echo fmt
 if [ ! -d fmt ]
 then
-	git clone https://github.com/fmtlib/fmt.git
+	git clone --filter=tree:0 https://github.com/fmtlib/fmt.git
 else 
 	cd Catch2
 	git pull
@@ -24,7 +24,7 @@ fi
 echo yaml-cpp
 if [ ! -d yaml-cpp ]
 then
-	git clone https://github.com/jbeder/yaml-cpp.git
+	git clone --filter=tree:0 https://github.com/jbeder/yaml-cpp.git
 else 
 	cd yaml-cpp
 	git pull
@@ -33,7 +33,7 @@ fi
 echo rapidyaml
 if [ ! -d rapidyaml ]
 then
-	git clone --recursive https://github.com/biojppm/rapidyaml.git
+	git clone --filter=tree:0 --recurse-submodules --also-filter-submodules https://github.com/biojppm/rapidyaml.git
 else 
 	cd rapidyaml
 	git pull 
@@ -43,7 +43,7 @@ fi
 echo GSL
 if [ ! -d GSL ]
 then
-	git clone https://github.com/microsoft/GSL.git
+	git clone --filter=tree:0 https://github.com/microsoft/GSL.git
 else 
 	cd GSL
 	git pull


### PR DESCRIPTION
We do not need the full git history of the external libraries. So, make only a 'treeless clone' to save on disk space and download volume.