### PR TITLE
Initial Docker image for testing and coverage test based on ubuntu:24.04

### DIFF
--- a/docker/ubuntu-24.04/.lcovrc
+++ b/docker/ubuntu-24.04/.lcovrc
@@ -1,0 +1,509 @@
+#
+# /etc/lcovrc - system-wide defaults for LCOV
+#
+# To change settings for a single user, place a customized copy of this file
+# at location ~/.lcovrc
+#
+# Note that this example script does not include all configuration options
+# see 'man lcovrc(5) for a complete list and usage description.
+
+# Specify an external style sheet file (same as --css-file option of genhtml)
+#genhtml_css_file = gcov.css
+
+# use 'dark' mode display (light foreground, dark background) instead of default
+# same as 'genhtml --dark-mode ....'
+#genhtml_dark_mode = 1
+
+# Header text to use at top of each page
+# Default is "LCOV - (differential )? coverage report"
+#genhtml_header = Coverage report for my project
+
+# Footer text to use at the bottom of each page
+# Default is LCOV tool version
+#genhtml_footer = My footer text
+
+# Specify global coverage rate limits (in %) for classifying file entries
+# HI:   hi_limit <= rate <= 100         graph color: green
+# MED: med_limit <= rate <  hi_limit    graph color: orange
+# LO:         0  <= rate <  med_limit   graph color: red
+genhtml_hi_limit = 90
+genhtml_med_limit = 75
+
+# Specify line coverage rate limits (in %) for classifying file entries
+# HI:  ln_hi_limit  <= rate <= 100            graph color: green
+# MED: ln_med_limit <= rate <  ln_hi_limit    graph color: orange
+# LO:            0  <= rate <  ln_med_limit   graph color: red
+# genhtml_line_hi_limit = 90
+# genhtml_line_med_limit = 75
+
+# Specify function coverage rate limits (in %) for classifying file entries
+# HI:  fn_hi_limit  <= rate <= 100            graph color: green
+# MED: fn_med_limit <= rate <  fn_hi_limit    graph color: orange
+# LO:            0  <= rate <  fn_med_limit   graph color: red
+# genhtml_function_hi_limit = 90
+# genhtml_function_med_limit = 75
+
+# Specify branch coverage rate limits (in %) for classifying file entries
+# HI:  br_hi_limit  <= rate <= 100            graph color: green
+# MED: br_med_limit <= rate <  br_hi_limit    graph color: orange
+# LO:            0  <= rate <  br_med_limit   graph color: red
+# genhtml_branch_hi_limit = 90
+# genhtml_branch_med_limit = 75
+
+# Ignore some errors during geninfo/lcov/genhtml processing - comma-separated
+# string.  Same as using "--ignore-errors a,b,c" command line option.
+# See man pages for list of ignorable messages
+#ignore_errors = empty,mismatch
+
+# Stop emitting message after this number have been printed
+# 0 == no limit
+max_message_count = 100
+
+# If set, do not stop when an 'ignorable error' occurs - try to generate
+#  a result, however flawed.  This is equivalent to the '--keep-going'
+#  command line switch.
+# Default is 1:  stop when error occurs
+# See the man pages for more detail
+stop_on_error = 0
+
+# If nonzero, treat warnings as error
+# note that ignored messages will still appear as warnings
+# Default is 0
+#treat_warning_as_error = 1
+
+# If set to non-zero, only issue particluar warning once per file
+# Default is 1
+#warn_once_per_file = 1
+
+# extension associated with lcov trace files - glob match pattern
+# used as argument to 'find' - to find coverage files contained in
+# a directory argument
+#info_file_pattern = *.info
+
+# List of file extensions which should be treated as RTL code (e.g., Verilog)
+# Comma-separated list.  Default is "v,vh,sv,vhd?"
+#rtl_file_extensions = v,vh,sv,vhd?
+
+# list of file extensions which should be treated as C/C++ code
+# (comma-separated list)
+#c_file_extensions = h,c,i,C,H,I,cpp,hpp,icc,cc,hh,cxx,hxx
+
+# list of file extensions which should be treated as Java code
+#java_file_extensions = java
+
+# list of file extensions which should be treated as perl code
+#perl_file_extensions = pl,pm
+
+# list of file extensions which should be treated as python code
+#python_file_extensions = py
+
+# maximum number of lines to look at, when filtering bogus branch expressions
+#filter_lookahead = 5
+
+# if nonzero, bitwise operators '|', '&', '~' indicate conditional expressions
+#filter_bitwise_conditional = 1
+
+# if nonzero, '--filter blank' is applied to blank lines, regardless
+# of their hit count
+#filter_blank_aggressive = 1
+
+# Width of line coverage field in source code view
+genhtml_line_field_width = 12
+
+# Width of branch coverage field in source code view
+genhtml_branch_field_width = 16
+
+# width of 'owner' field in source code view - default is 20
+#genhtml_owner_field_width = 20
+
+# width of 'age' field in source code view - default is 5
+#genhtml_age_field_width = 5
+
+# Width of overview image (used by --frames option of genhtml)
+genhtml_overview_width = 80
+
+# Resolution of overview navigation: this number specifies the maximum
+# difference in lines between the position a user selected from the overview
+# and the position the source code window is scrolled to (used by --frames
+# option of genhtml)
+genhtml_nav_resolution = 4
+
+# Clicking a line in the overview image should show the source code view at
+# a position a bit further up so that the requested line is not the first
+# line in the window. This number specifies that offset in lines (used by
+# --frames option of genhtml)
+genhtml_nav_offset = 10
+
+# Do not remove unused test descriptions if non-zero (same as
+# --keep-descriptions option of genhtml)
+genhtml_keep_descriptions = 0
+
+# Do not remove prefix from directory names if non-zero (same as --no-prefix
+# option of genhtml)
+genhtml_no_prefix = 0
+
+# Do not create source code view if non-zero (same as --no-source option of
+# genhtml)
+genhtml_no_source = 0
+
+# Replace tabs with number of spaces in source view (same as --num-spaces
+# option of genhtml)
+genhtml_num_spaces = 8
+
+# Include color legend in HTML output if non-zero (same as --legend option of
+# genhtml)
+genhtml_legend = 0
+
+# Use FILE as HTML prolog for generated pages (same as --html-prolog option of
+# genhtml)
+#genhtml_html_prolog = FILE
+
+# Use FILE as HTML epilog for generated pages (same as --html-epilog option of
+# genhtml)
+#genhtml_html_epilog = FILE
+
+# Use custom filename extension for pages (same as --html-extension option of
+# genhtml)
+#genhtml_html_extension = html
+
+# Compress all generated html files with gzip.
+#genhtml_html_gzip = 1
+
+# Include sorted overview pages (can be disabled by the --no-sort option of
+# genhtml)
+genhtml_sort = 1
+
+# Display coverage idata in hierarchical directory structure rather than
+# top/directory/source
+#genhtml_hierarchical = 1
+
+# Display coverage data using 'flat' view:  top-level table holds all
+#  files with no intermediate directory pages.
+#genhtml_flat_view = 1
+
+# Enable hyperlinks from coverage summary table to first source code line
+#   in corresponding category ('Hit' or "Missed') in non-differential report.
+# Feature is always enabled in differential coverage report.
+#genhtml_show_navigation = 1
+
+# If nonzero, add column to "function coverage detail" table to show the proportion of lines and branches within the function which are exercised.
+#genhtml_show_function_proportion = 0
+
+# Specify the character set of all generated HTML pages
+genhtml_charset=UTF-8
+
+# Allow HTML markup in test case description text if non-zero
+genhtml_desc_html=0
+
+# Specify the precision for coverage rates
+#genhtml_precision=1
+
+# Show missed counts instead of hit counts
+#genhtml_missed=1
+
+# group function aliases in report - see '--merge' section in man(1) genhtml
+#merge_function_aliasess = 1
+
+# If set, suppress list of aliases in function detail table
+#suppress_function_aliases = 1
+
+# If set, derive function end line from line coverpoint data - default ON
+#derive_function_end_line = 1
+
+# If set, derive function end lines for all file types.
+# By default, we derive end lines for C/C++ files only
+#derive_end_line_all_files = 0
+
+# Maximum size of function (number lines) which will be checked by '--filter trivial'
+#trivial_function_threshold = 5
+
+# Set threshold for hit count which tool should deem likely to indicate
+# a toolchain bug (corrupt coverage data)
+# excessive_count_theshold = number
+
+# Demangle C++ symbols
+# Call multiple times to specify command and command line arguments
+#  ('-Xlinker'-like behaviour)
+#demangle_cpp = c++filt
+
+# Name of the tool used for demangling C++ function names
+# This argument is deprecated - please use 'demangle_cpp' instead
+#genhtml_demangle_cpp_tool = c++filt
+# Specify extra parameters to be passed to the demangling tool
+# This argument is deprecated - please use 'demangle_cpp' instead
+#genhtml_demangle_cpp_params = ""
+
+# Location of the gcov tool (same as --gcov-info option of geninfo)
+#geninfo_gcov_tool = gcov
+
+# Adjust test names to include operating system information if non-zero
+#geninfo_adjust_testname = 0
+
+# Ignore testcase names in .info file
+#forget_testcase_names = 0
+
+# Calculate checksum for each source code line if non-zero (same as --checksum
+# option of geninfo if non-zero, same as --no-checksum if zero)
+#checksum = 1
+
+# Specify whether to capture coverage data for external source files (can
+# be overridden by the --external and --no-external options of geninfo/lcov)
+#geninfo_external = 1
+geninfo_external = 0
+
+# Specify whether to capture coverage data from compile-time data files
+# which have no corresponding runtime data.
+#geninfo_capture_all = 1
+
+# Enable libtool compatibility mode if non-zero (same as --compat-libtool option
+# of geninfo if non-zero, same as --no-compat-libtool if zero)
+#geninfo_compat_libtool = 0
+
+# Use gcov's --all-blocks option if non-zero
+#geninfo_gcov_all_blocks = 1
+
+# Adjust 'executed' non-zero hit count of lines which contain no branches
+# and have attribute '"unexecuted_blocks": true'
+#geninfo_unexecuted_blocks = 0
+
+# Specify compatibility modes (same as --compat option of geninfo).
+#geninfo_compat = libtool=on, hammer=auto, split_crc=auto
+
+# Adjust path to source files by removing or changing path components that
+# match the specified pattern (Perl regular expression format)
+#geninfo_adjust_src_path = /tmp/build => /usr/src
+
+# Specify if geninfo should try to automatically determine the base-directory
+# when collecting coverage data.
+geninfo_auto_base = 1
+
+# Use gcov intermediate format? Valid values are 0, 1, auto
+geninfo_intermediate = auto
+
+# Specify if exception branches should be excluded from branch coverage.
+no_exception_branch = 0
+
+# Directory containing gcov kernel files
+# lcov_gcov_dir = /proc/gcov
+
+# Location of the insmod tool
+lcov_insmod_tool = /sbin/insmod
+
+# Location of the modprobe tool
+lcov_modprobe_tool = /sbin/modprobe
+
+# Location of the rmmod tool
+lcov_rmmod_tool = /sbin/rmmod
+
+# Location for temporary directories
+lcov_tmp_dir = /tmp
+
+# Show full paths during list operation if non-zero (same as --list-full-path
+# option of lcov)
+lcov_list_full_path = 0
+
+# Specify the maximum width for list output. This value is ignored when
+# lcov_list_full_path is non-zero.
+lcov_list_width = 80
+
+# Specify the maximum percentage of file names which may be truncated when
+# choosing a directory prefix in list output. This value is ignored when
+# lcov_list_full_path is non-zero.
+lcov_list_truncate_max = 20
+
+# Specify if function coverage data should be collected, processed, and displayed
+function_coverage = 1
+
+# Specify if branch coverage data should be collected, processed, and displayed
+branch_coverage = 0
+
+# Ask lcov/genhtml/geninfo to return non-zero exit code if branch coverage is below
+# threshold
+# Default is 0.0 - i.e., do not check threshold.
+#fail_under_branches = 75.0
+
+# Ask lcov/genhtml/geninfo to return non-zero exit code if line coverage is below
+# threshold
+# Default is 0.0 - i.e., do not check threshold.
+#fail_under_lines = 97.5
+
+# specify revision control annotation script for genhtml
+#genhtml_annotate_script = path_to_my_executable
+
+# specify the annotation popup that will appear if user hovers over source code
+# set to empty to elide tooltip
+# Substitutions:
+#  %d:  line number
+#  %C:  commit ID (from annotate callback - see --anotate-script entry in
+#       genhtml documentation)
+#  %U:  commit author abbreviated name
+#  %F:  commit author full name
+#  %D:  commit date (as returned by annotate callback)
+#  %d:  simplified commit date - yyyy-mm-dd part only (remove time of day)
+#  %A:  commit age
+#  %l:  line number
+#genhtml_annotate_tooltip = Commit ID: %C by %F on %D
+
+# specify coverage criteria script for genhtml/lcov/geninfo
+#criteria_script = path_to_my_executable_or_module
+
+# specify whether you want date and/or owner information passed to your criteria
+# callback - in addition to summary information, which is always returned
+#criteria_callback_data = date,owner
+
+# specify when the criteria callback will be executed
+#criteria_callback_levels = top,directory,file
+
+# specify callback to decide whether particular source line should be
+# included or suppresses
+# select_script = path_to_exe | callback_parameter
+
+# specify number of lines of context to include around each selected
+#  source line
+# num_context_lines = 5
+
+# specify age cutpoints for genhtml date bins
+# can call option multiple times or use comma-separted list (or both)
+#genhtml_date_bins = 7
+#genhtml_date_bins = 30,180
+
+# if enabled, show 'author' coverpoint summary table in page headers
+# if not 'all', then show only authors who are responsible for coverpoints
+# which are not hit
+#genhtml_show_owner_table = 0 | 1 | all
+
+# truncate owner table to show at most this many authors -
+#  subset will be those with the highest count of un-exercised code
+# owner_table_entries = 5
+
+# truncate the owner table at this level/these levels only
+#  possible values are 'file', 'directory', 'top' (without quotes)
+#  option may be specified multiple times and/or as a comma-separated list
+# truncate_owner_table = top,directory,file
+
+# if enabled, show author of non-code source lines (e.g., comments)
+# in 'source' detail column
+#genhtml_show_noncode_owners = 0 | 1
+
+# if enabled, generate fake source code for missing files and out-of-range
+# lines
+#genhtml_synthesize_missing = 0 | 1
+
+
+# ask geninfo/lcov/genhtml to include only certain files (glob match pattern)
+# call multiple times to specify multiple patterns
+#include = my/files/*.c
+#include = my/files/*.h
+include = src/*.cpp
+include = src/*.h
+
+# ask geninfo/lcov/genhtml to exclude certain files (glob match pattern)
+# call multiple times to specify multiple patterns
+#exclude = your/files/*.c
+#exclude = your/files/*.h
+exclude = external/
+exclude = build/
+
+# ask geninfo/lcov/genhtml to munge file pathnames when reading/writing .info files
+# call multiple times to specify multiple patterns
+#  this pattern removes "/.lib" from the pathname (see the lcov man page for details)
+#substitute = s#/.libs##g
+#  this pattern changes "/tmp/build" to "/usr/src" (see the lcov man page for details)
+#substitute = s#/tmp/build#/usr/src#g
+
+# ask geninfo/lcov/genhtml to exclude coverpoints associated with lines which match
+# the regexp.  Call multiple times to specify multiple patterns
+#   omit lines which end with "// MY_LINE_EXCLUDE_MARKER
+#omit_lines = .+?//\s*MY_LINE_EXCLUDE_MARKER\s*
+#   add another exclusion marker
+#omit_lines = .+?//\s*MY_PROJECT_EXCLUDE_MARKER\s*
+
+# ask geninfo/lcov/genhtml to exclude coverpoints whose lines are within
+#  the start/end of a function matching the regexp.
+#Call multiple times to specify multiple patterns
+#erase_functions = main
+# and another - note that this looks like a demangled C++ function
+# that the argument is a regexp - so special characters need to be escaped
+#erase_functions = debug)_.*\(int,\s*int\)
+
+# check that source file exists before calling version-script, annotate-script
+# or other callback.  If set and file does not exist, 'source' error is
+# generated.  Default: 1 (check for existence).
+#check_existence_before_callback = 1
+
+# specify path to version identification script
+#version_script = path_to_my_executable
+
+# tell the tool to genenerate missing file version information when
+# readind coverage DB file
+# compute_file_version = 0 | 1
+
+# specify path to file pathname resolution script
+#resolve_script = path_to_my_executable
+
+# Specify JSON module to use, or choose best available if set to auto
+lcov_json_module = auto
+
+# Specify maximum number of parallel slaves
+# default: 1 (no parallelism)
+#parallel = 1
+
+# Specify maximum memory to use during parallel processing, in Mb.
+# Do not fork if estimated memory consumption exceeds this number.
+# default: 0 (no limit)
+#memory = 1024
+
+# Specify the number of consecutive fork() failures to allow before
+# giving up
+# max_fork_fails = 5
+
+# Throtting control:  the maximum number of files that genhtml will
+# handle in a single (parallel) thread
+# max_tasks_per_core = 20
+
+# Seconds to wait after failing to fork() before retrying
+# fork_fail_timeout = 10
+
+# Throttling control:  specify a percentage of system memory to use as
+# maximum during parallel processing.
+# Do not fork if estimated memory consumption exceeds the maximum.
+# this value is used only if the maximum memory is not set.
+# default: not set
+#memory_percentage = 1024
+
+
+# Character used to split list-type parameters
+#  - for example, the list of "--ignore_errors source,mismatch"
+# default: , (comma)
+#split_char = ,
+
+# use case insensitive compare to find matching files, for include/exclude
+#  directives, etc
+#case_insensitive = 0
+
+# override line default line exclusion regexp
+#lcov_excl_line = LCOV_EXCL_LINE
+
+# override branch exclusion regexp
+#lcov_excl_br_line = LCOV_EXCL_BR_LINE
+
+# override exception branch exclusion regexp
+#lcov_excl_exception_br_line = LCOV_EXCL_EXCEPTION_BR_LINE
+
+# override start of exclude region regexp
+#lcov_excl_start = LCOV_EXCL_START
+
+# override end of exclude region regexp
+#lcov_excl_stop = LCOV_EXCL_STOP
+
+# override start of branch exclude region regexp
+#lcov_excl_br_start = LCOV_EXCL_BR_START
+
+# override start of exclude region regexp
+#lcov_excl_br_stop = LCOV_EXCL_BR_STOP
+
+# override start of exclude region regexp
+#lcov_excl_exception_br_start = LCOV_EXCL_EXCEPTION_BR_START
+
+# override start of exclude region regexp
+#lcov_excl_exception_br_stop = LCOV_EXCL_EXCEPTION_BR_STOP

--- a/docker/ubuntu-24.04/Dockerfile
+++ b/docker/ubuntu-24.04/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04
+
+WORKDIR /root
+
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    cmake \
+    libboost-system-dev \
+    libboost-program-options-dev \
+    libncurses-dev \
+    libcap-dev \
+    bats \
+    bats-assert \
+    bats-file \
+    lcov
+
+
+WORKDIR /ws
+
+COPY .lcovrc .
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/ubuntu-24.04/README.md
+++ b/docker/ubuntu-24.04/README.md
@@ -1,0 +1,11 @@
+Docker container based on ubuntu:24.04 that contains all the necessary
+packages to build and run hpc-workspace-v2 with all tests.
+Can generate coverage data, as well.
+
+Container can be run with four commands: 'ctest', 'bats', 'testall', and
+'lcov'. The first three just run the tests. The 'lcov' command will
+run all tests and produce a coverage report. The coverage test results
+will be in the /ws/coverage_report folder in the container. Either
+copy the folder manually to the host after the lcov run or bind mount
+the folder to the host when starting the container.
+

--- a/docker/ubuntu-24.04/entrypoint.sh
+++ b/docker/ubuntu-24.04/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+command="$1"
+
+
+run_bats_test=false
+run_ctest_test=false
+run_coverage=false
+
+case "$command" in
+  bats)
+    run_bats_test=true
+    ;;
+  ctest)
+    run_ctest_test=true
+    ;;
+  lcov)
+    run_bats_test=true
+    run_ctest_test=true
+    run_coverage=true
+    ;;
+  testall)
+    run_bats_test=true
+    run_ctest_test=true
+    ;;
+  *)
+    echo "available commands are: bats, ctest, lcov, testall"
+    echo "for lcov please mount the container directory /ws/coverage_report to get your results"
+    exit 1
+    ;;
+esac
+
+
+if [ "$run_bats_test" = true ] || [ "$run_ctest_test" = true ]; then
+
+  git clone https://github.com/holgerBerger/hpc-workspace-v2.git
+  cd hpc-workspace-v2/external
+  ./get_externals.sh
+  cd ..
+
+  if [ "$run_coverage" = true ]; then
+    cmake --preset debug -DCMAKE_CXX_FLAGS=--coverage
+  else
+    cmake --preset debug
+  fi
+
+  cmake --build --preset debug -j
+
+  if [ "$run_coverage" = true ]; then
+    lcov --capture --initial --config-file ../.lcovrc --directory . -o ws_base.info
+  fi
+
+  if [ "$run_ctest_test" = true ]; then
+    ctest --preset debug
+  fi
+  if [ "$run_bats_test" = true ]; then
+    bats bats/test
+  fi
+
+  if [ "$run_coverage" = true ]; then
+    lcov --capture --config-file ../.lcovrc --directory . -o ws_test.info
+    lcov -a ws_base.info -a ws_test.info -o ws_total.info
+    genhtml  --ignore-errors source --output-directory ../coverage_report ws_total.info
+  fi
+fi


### PR DESCRIPTION
Docker container based on ubuntu:24.04 that contains all the necessary packages to build and run hpc-workspace-v2 with all tests. Can generate coverage data, as well.

Container can be run with four commands: 'ctest', 'bats', 'testall', and 'lcov'. The first three just run the tests. The 'lcov' command will run all tests and produce a coverage report. The coverage test results will be in the /ws/coverage_report folder in the container. Either copy the folder manually to the host after the lcov run or bind mount the folder to the host when starting the container.