### PR TITLE
Move utils::printBuildFlags into its own header 'build_info.h'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ws_common
+    build_info.h
     caps.cpp
     caps.h
     config.cpp

--- a/src/build_info.h
+++ b/src/build_info.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+#include <fmt/base.h>
+
+#include "caps.h"
+
+extern Cap caps;
+
+
+namespace utils {
+
+	// helper to print build flags
+	void printBuildFlags() {
+		bool parallel = false;
+		bool userdebug = false;
+		bool capa = false;
+
+#ifdef WS_PARALLEL
+		parallel = true;
+#endif
+#ifdef WS_ALLOW_USER_DEBUG
+		userdebug = true;
+#endif
+#ifdef WS_CAPA
+		capa = true;
+#endif
+		fmt::println("Build flags: WS_PARALLEL={}, WS_CAPA={}, WS_ALLOW_USER_DEBUG={}",parallel,capa,userdebug);
+		fmt::println("Runtime flags: isusermode={}, issetuid={}, hascaps={}", caps.isUserMode(), caps.isSetuid(), caps.hasCaps());
+	}
+
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -173,26 +173,6 @@ namespace utils {
 		}
 	}
 
-
-	// helper to print flags
-	void printBuildFlags() {
-		bool parallel = false;
-		bool userdebug = false;
-		bool capa = false;
-
-#ifdef WS_PARALLEL
-		parallel = true;
-#endif
-#ifdef WS_ALLOW_USER_DEBUG
-		userdebug = true;
-#endif
-#ifdef WS_CAPA
-		capa = true;
-#endif
-		fmt::println("Build flags: WS_PARALLEL={}, WS_CAPA={}, WS_ALLOW_USER_DEBUG={}",parallel,capa,userdebug);
-		fmt::println("Runtime flags: isusermode={}, issetuid={}, hascaps={}", caps.isUserMode(), caps.isSetuid(), caps.hasCaps());
-	}
-
 	// we only support C locale, if the used local is not installed on the system
 	// ws_allocate fails, this should be called in all tools
 	//  problem showed with a remote SuSE machine with DE locale, coming through ssh

--- a/src/utils.h
+++ b/src/utils.h
@@ -63,9 +63,6 @@ namespace utils {
     // retrurn list of filesnames mit unix name globbing
     std::vector<std::string> dirEntries(const std::string path, const std::string pattern);
 
-    // print CMake flags
-    void printBuildFlags();
-
     // set C local in every thinkable way
     void setCLocal();
 

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -36,6 +36,7 @@
 
 #include <syslog.h>
 
+#include "build_info.h"
 #include "config.h"
 #include "user.h"
 #include "utils.h"

--- a/src/ws_find.cpp
+++ b/src/ws_find.cpp
@@ -39,6 +39,7 @@
 #include <boost/program_options.hpp>
 #include "config.h"
 
+#include "build_info.h"
 #include "db.h"
 #include "user.h"
 #include "fmt/base.h"

--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -52,6 +52,7 @@
 #include <boost/program_options.hpp>
 #include "config.h"
 
+#include "build_info.h"
 #include "db.h"
 #include "user.h"
 #include "fmt/base.h"

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -36,6 +36,7 @@
 
 #include <syslog.h>
 
+#include "build_info.h"
 #include "config.h"
 #include "user.h"
 #include "utils.h"

--- a/tests/UserConfig_test.cpp
+++ b/tests/UserConfig_test.cpp
@@ -1,15 +1,11 @@
-#include "../src/UserConfig.h"
-
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 #include <catch2/catch_test_macros.hpp>
 
 #include "../src/UserConfig.h"
-#include "../src/caps.h"
 
 bool debugflag = false;
 bool traceflag = false;
 
-Cap caps{};
 
 TEST_CASE("User config yaml format", "[userconfig]") {
 


### PR DESCRIPTION
Reduce unnecessary dependencies to caps if they are not needed, e.g., in basic unit tests.

Note: By including the header the actual build flags for the current
      compilation unit will be shown instead of the once applying only
      to 'utils.cpp'.