### PR TITLE
Initial Docker image for testing based on rockylinux:9.5

### DIFF
--- a/docker/rockylinux-9.5/Dockerfile
+++ b/docker/rockylinux-9.5/Dockerfile
@@ -1,0 +1,46 @@
+FROM rockylinux/rockylinux:9.5
+
+WORKDIR /root
+
+RUN dnf install -y \
+    git \
+    cmake \
+    g++ \
+    libasan \
+    libubsan \
+    boost-devel \
+    ncurses-devel \
+    libcap-devel \
+    wget \
+    which
+
+# Installing libs for static build;
+# Note: nothing there for libcap ... :/
+#RUN dfn --enablerepo=crb \
+#    glibc-static \
+#    libstdc++-static \
+#    boost-static
+
+
+# no rpms for the following packages in the repo:
+#    bats
+#    bats-assert
+#    bats-file
+#    lcov
+
+# Installing bats and libraries based on documentation and their Dockerfile
+RUN git clone https://github.com/bats-core/bats-core.git
+WORKDIR bats-core
+RUN ./install.sh /opt/bats
+RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
+RUN ./docker/install_libs.sh support 0.3.0
+RUN ./docker/install_libs.sh assert 2.1.0
+RUN ./docker/install_libs.sh file 0.4.0
+
+
+WORKDIR /ws
+
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/rockylinux-9.5/README.md
+++ b/docker/rockylinux-9.5/README.md
@@ -1,0 +1,4 @@
+Docker container based on RockyLinux:9.5 that contains all the necessary
+packages to build and run hpc-workspace-v2 with all tests.
+
+Container can be run with three commands: 'ctest', 'bats', and 'testall'.

--- a/docker/rockylinux-9.5/entrypoint.sh
+++ b/docker/rockylinux-9.5/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+command="$1"
+
+
+run_bats_test=false
+run_ctest_test=false
+
+case "$command" in
+  bats)
+    run_bats_test=true
+    ;;
+  ctest)
+    run_ctest_test=true
+    ;;
+  testall)
+    run_bats_test=true
+    run_ctest_test=true
+    ;;
+  *)
+    echo "available commands are: bats, ctest, testall"
+    exit 1
+    ;;
+esac
+
+
+if [ "$run_bats_test" = true ] || [ "$run_ctest_test" = true ]; then
+
+  git clone https://github.com/holgerBerger/hpc-workspace-v2.git
+  cd hpc-workspace-v2/external
+  ./get_externals.sh
+  cd ..
+
+  cmake --preset debug
+  cmake --build --preset debug -j
+
+  if [ "$run_ctest_test" = true ]; then
+    ctest --preset debug
+  fi
+  if [ "$run_bats_test" = true ]; then
+    bats bats/test
+  fi
+
+fi


### PR DESCRIPTION
Docker container based on RockyLinux:9.5 that contains all the necessary packages to build and run hpc-workspace-v2 with all tests.

Container can be run with three commands: 'ctest', 'bats', and 'testall'.