### PR TITLE
Minor fix in ws_allocate command line parsing

### DIFF
--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -93,7 +93,7 @@ void commandline(po::variables_map &opt, string &name, int &duration, const int 
 
     // define options without names
     po::positional_options_description p;
-    p.add("name", 1).add("duration",2);
+    p.add("name", 1).add("duration", 1);
 
     po::options_description all_options;
     all_options.add(cmd_options).add(secret_options);


### PR DESCRIPTION
Allow command line option for duration to be passed only once.