### PR TITLE
Fix ws tools return value

### DIFF
--- a/bats/test/ws_allocate.bats
+++ b/bats/test/ws_allocate.bats
@@ -12,11 +12,13 @@ setup() {
 @test "ws_allocate print version" {
     run ws_allocate --version
     assert_output --partial "workspace"
+    assert_success
 }
 
 @test "ws_allocate print help" {
     run ws_allocate --help
     assert_output --partial "Usage"
+    assert_success
 }
 
 @test "ws_allocate creates directory" {

--- a/bats/test/ws_find.bats
+++ b/bats/test/ws_find.bats
@@ -13,11 +13,13 @@ setup() {
 @test "ws_find print version" {
     run ws_find --version
     assert_output --partial "workspace"
+    assert_success
 }
 
 @test "ws_find print help" {
     run ws_find --help
     assert_output --partial "Usage"
+    assert_success
 }
 
 @test "ws_find finds directory" {

--- a/bats/test/ws_list.bats
+++ b/bats/test/ws_list.bats
@@ -14,11 +14,13 @@ setup() {
 @test "ws_list print version" {
     run ws_list --version
     assert_output --partial "workspace"
+    assert_success
 }
 
 @test "ws_list print help" {
     run ws_list --help
     assert_output --partial "Usage"
+    assert_success
 }
 
 @test "ws_list shows created workspace" {

--- a/bats/test/ws_release.bats
+++ b/bats/test/ws_release.bats
@@ -13,11 +13,13 @@ setup() {
 @test "ws_allocate print version" {
     run ws_release --version
     assert_output --partial "workspace"
+    assert_success
 }
 
 @test "ws_release print help" {
     run ws_release --help
     assert_output --partial "Usage"
+    assert_success
 }
 
 @test "ws_release releases directory" {

--- a/bats/test/ws_restore.bats
+++ b/bats/test/ws_restore.bats
@@ -1,0 +1,20 @@
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "ws_restore present" {
+    which ws_restore
+}
+
+@test "ws_restore print version" {
+    run ws_restore --version
+    assert_output --partial "workspace"
+    assert_success
+}
+
+@test "ws_restore print help" {
+    run ws_restore --help
+    assert_output --partial "Usage"
+    assert_success
+}

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -115,7 +115,7 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
     if (opt.count("help")) {
         fmt::print("Usage: {} [options] workspace_name duration\n", argv[0]);
         cout << cmd_options << "\n";
-        exit(1);
+        exit(0);
     }
 
     if (opt.count("version")) {
@@ -125,7 +125,7 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
         fmt::println("workspace version {}", WS_VERSION );
 #endif
         utils::printBuildFlags();
-        exit(1);
+        exit(0);
     }
 
     // this allows user to extend foreign workspaces

--- a/src/ws_find.cpp
+++ b/src/ws_find.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
     if (opts.count("help")) {
         fmt::print("Usage: {} [options] name\n", argv[0]);
         cout << cmd_options << endl; 
-        exit(1);
+        exit(0);
     }
 
     if (opts.count("version")) {

--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
     if (opts.count("help")) {
         fmt::print("Usage: {} [options] [pattern]\n", argv[0]);
         cout << cmd_options << endl; // FIXME: can not be printed with fmt??
-        exit(1);
+        exit(0);
     }
 
     if (opts.count("version")) {

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -111,7 +111,7 @@ void commandline(po::variables_map &opt, string &name, string &filesystem,
     if (opt.count("help")) {
         fmt::print("Usage: {} [options] workspace_name duration\n", argv[0]);
         cout << cmd_options << "\n";
-        exit(1);
+        exit(0);
     }
 
     if (opt.count("version")) {
@@ -121,7 +121,7 @@ void commandline(po::variables_map &opt, string &name, string &filesystem,
         fmt::println("workspace version {}", WS_VERSION );
 #endif
         utils::printBuildFlags();
-        exit(1);
+        exit(0);
     }
 
     // this allows user to extend foreign workspaces

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -103,7 +103,7 @@ void commandline(po::variables_map &opt, string &name, string &target,
         cout << "Usage:" << argv[0] << ": [options] workspace_name target_name | -l" << endl;
         cout << cmd_options << "\n";
                 cout << "attention: the workspace_name argument is as printed by " << argv[0] << " -l not as printed by ws_list!" << endl;
-        exit(1);
+        exit(0);
     }
 
     if (opt.count("version")) {
@@ -113,7 +113,7 @@ void commandline(po::variables_map &opt, string &name, string &target,
 #else
         cout << "workspace version " << WS_VERSION << endl;
 #endif
-        exit(1);
+        exit(0);
     }
 
     if (opt.count("list")) {


### PR DESCRIPTION
If the user explicitly requests help or version information from a ws tool this should not return an error code.

- [x] Updated exit statements (which were also inconsistent between tools currently)
- [x] Updated/added bats tests to check return code for ws tools