### PR TITLE
Docker image for static building based on rockylinux:9.5

### DIFF
--- a/docker/rockylinux-9.5-static/Dockerfile
+++ b/docker/rockylinux-9.5-static/Dockerfile
@@ -1,0 +1,27 @@
+FROM rockylinux/rockylinux:9.5
+
+WORKDIR /root
+
+RUN dnf install -y \
+    git \
+    cmake \
+    g++ \
+    boost-devel \
+    wget \
+    which
+
+# do not need the following for release builds
+#    libasan \
+#    libubsan \
+
+# do not install the following or cmake will try to build with it but fails
+# due to missing static versions of the librarires
+#    ncurses-devel \
+#    libcap-devel \
+
+# Installing libs for static build;
+RUN dnf --enablerepo=crb install -y \
+    glibc-static \
+    libstdc++-static \
+    boost-static
+


### PR DESCRIPTION
Docker container based on RockyLinux:9.5 that contains packages to build and run hpc-workspace-v2 as a static application without ncurses/libterm as well as capabilities (libcap).