### PR TITLE
Add .git-blame-ignore-revs to ignore excessive clang-format changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# For vscode with the GitLense extension add the following to the settings.json:
+# "gitlens.advanced.blame.customArguments": ["--ignore-revs-file .git-blame-ignore-revs"]
+
+# Ignore code reformating with clang-format
+53dc910a1ae10b8408a25fac422e78c156de9540


### PR DESCRIPTION
The .git-blame-ignore-revs file can be used by git blame, vscode, and is also taken into account by GitHub to ignore changes from commits listed in this file, To set this up see instructions in the file itself.