### PR TITLE
Reminder and Error-Mails for ws_expirer

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -84,6 +84,7 @@ class DBEntry {
     virtual long getExpiration() const = 0;
     virtual long getReleaseTime() const = 0;
     virtual string getFilesystem() const = 0;
+    virtual long getReminder() const = 0;
 
     // get config of parent DB
     virtual const Config* getConfig() const = 0;

--- a/src/dbv1.cpp
+++ b/src/dbv1.cpp
@@ -544,6 +544,8 @@ long DBEntryV1::getReleaseTime() const { return released; }
 
 string DBEntryV1::getFilesystem() const { return filesystem; }
 
+long DBEntryV1::getReminder() const { return reminder; }
+
 // change expiration time
 void DBEntryV1::setExpiration(const time_t timestamp) { expiration = timestamp; }
 

--- a/src/dbv1.h
+++ b/src/dbv1.h
@@ -106,6 +106,7 @@ class DBEntryV1 : public DBEntry {
     long getExpiration() const;
     long getReleaseTime() const;
     string getFilesystem() const;
+    long getReminder() const;
 
     // return config of parent DB
     const Config* getConfig() const;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -560,14 +560,24 @@ std::string generateMessageID(const std::string& domain) {
     return fmt::format("{}.{}.{}@{}", now, pid, hash, domain);
 }
 
+// generate the To Header for Mails
+std::string generateToHeader(std::vector<std::string> mail_to) {
+    std::string to_header;
+    for (size_t i = 0; i < mail_to.size(); ++i) {
+        if (i > 0) to_header += ", ";
+        to_header += mail_to[i];
+    }
+    return to_header;
+}
+
 // Initialze curl
 void initCurl() { curl_global_init(CURL_GLOBAL_DEFAULT); }
 
-//Cleanup curl
+// Cleanup curl
 void cleanupCurl() { curl_global_cleanup(); }
 
 // Send the a Mail with curl to the smtpUrl
-bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, const std::string& mail_to,
+bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, std::vector<std::string>& mail_to,
               const std::string& completeMail) {
     CURL* curl;
     CURLcode res = CURLE_OK;
@@ -584,7 +594,9 @@ bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, const st
     curl_easy_setopt(curl, CURLOPT_URL, smtpUrl.c_str());
 
     struct curl_slist* recipients = nullptr;
-    recipients = curl_slist_append(recipients, mail_to.c_str());
+    for (const auto& mailaddress : mail_to){
+        recipients = curl_slist_append(recipients, mailaddress.c_str());
+    }
     curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
     curl_easy_setopt(curl, CURLOPT_MAIL_FROM, mail_from.c_str());
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -540,8 +540,30 @@ std::string trimright(const char* in) {
     return str;
 }
 
+// Generate the Date Format used for Mime Mails from time_t
+std::string generateMailDateFormat(const time_t time) {
+    char timeString[std::size("Mon, 29 Nov 2010 21:54:29 +1100")];
+    std::strftime(std::data(timeString), std::size(timeString), "%a, %d %h %Y %X %z", std::localtime(&time));
+    std::string s(timeString);
+    return s;
+}
+
+// Generate a message ID from current time, PID, and Random component
+std::string generateMessageID(const std::string& domain) {
+    auto now = std::time(nullptr);
+    auto pid = getpid();
+
+    std::hash<std::string> hasher;
+    std::string unique_string = std::to_string(now) + std::to_string(pid) + std::to_string(rand());
+    auto hash = hasher(unique_string);
+
+    return fmt::format("{}.{}.{}@{}", now, pid, hash, domain);
+}
+
+// Initialze curl
 void initCurl() { curl_global_init(CURL_GLOBAL_DEFAULT); }
 
+//Cleanup curl
 void cleanupCurl() { curl_global_cleanup(); }
 
 // Send the a Mail with curl to the smtpUrl

--- a/src/utils.h
+++ b/src/utils.h
@@ -113,6 +113,9 @@ std::string generateMailDateFormat(const time_t time);
 // Generate a message ID from current time, PID, and Random component
 std::string generateMessageID(const std::string& domain = "ws_send_ical");
 
+// generate the To Header for Mails
+std::string generateToHeader(std::vector<std::string> mail_to);
+
 // Initialize Curl
 void initCurl();
 
@@ -120,7 +123,7 @@ void initCurl();
 void cleanupCurl();
 
 // Send the a Mail with curl to the smtpUrl
-bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, const std::string& mail_to,
+bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, std::vector<std::string>& mail_to,
               const std::string& completeMail);
 
 } // namespace utils

--- a/src/utils.h
+++ b/src/utils.h
@@ -107,10 +107,19 @@ void setupLogging(const std::string ident);
 std::string trimright(const std::string& in);
 std::string trimright(const char* in);
 
+// Generate the Date Format used for Mime Mails from time_t/long
+std::string generateMailDateFormat(const time_t time);
+
+// Generate a message ID from current time, PID, and Random component
+std::string generateMessageID(const std::string& domain = "ws_send_ical");
+
+// Initialize Curl
 void initCurl();
 
+// Cleanup Curl 
 void cleanupCurl();
 
+// Send the a Mail with curl to the smtpUrl
 bool sendCurl(const std::string& smtpUrl, const std::string& mail_from, const std::string& mail_to,
               const std::string& completeMail);
 

--- a/src/ws_send_ical.cpp
+++ b/src/ws_send_ical.cpp
@@ -170,14 +170,6 @@ std::string generateICSDateFormat(const time_t time) {
     return s;
 }
 
-// Generate the Date Format used for Mime Mails from time_t
-std::string generateMailDateFormat(const time_t time) {
-    char timeString[std::size("Mon, 29 Nov 2010 21:54:29 +1100")];
-    std::strftime(std::data(timeString), std::size(timeString), "%a, %d %h %Y %X %z", std::localtime(&time));
-    std::string s(timeString);
-    return s;
-}
-
 // Encode ics input for Base64
 std::string base64Encode(const std::string& input) {
     const std::string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -256,18 +248,6 @@ std::string generateICS(const std::unique_ptr<DBEntry>& entry, const std::string
     return ics.str();
 }
 
-// Generate a message ID from current time, PID, and Random component
-std::string generateMessageID(const std::string& domain = "ws_send_ical") {
-    auto now = std::time(nullptr);
-    auto pid = getpid();
-
-    std::hash<std::string> hasher;
-    std::string unique_string = std::to_string(now) + std::to_string(pid) + std::to_string(rand());
-    auto hash = hasher(unique_string);
-
-    return fmt::format("{}.{}.{}@{}", now, pid, hash, domain);
-}
-
 // Generate the Mail
 std::string generateMail(const std::unique_ptr<DBEntry>& entry, std::string ics, const std::string mail_from,
                          const std::string mail_to, const std::string clustername, time_t now) {
@@ -275,10 +255,10 @@ std::string generateMail(const std::unique_ptr<DBEntry>& entry, std::string ics,
     std::string resource = entry->getFilesystem();
 
     std::stringstream mail;
-    std::string expirationtimestr = generateMailDateFormat(entry->getExpiration());
-    std::string createtimestr = generateMailDateFormat(now);
+    std::string expirationtimestr = utils::generateMailDateFormat(entry->getExpiration());
+    std::string createtimestr = utils::generateMailDateFormat(now);
     std::string boundary = "_NextPart_01234567.89ABCDEF";
-    std::string messageID = generateMessageID();
+    std::string messageID = utils::generateMessageID();
 
     std::string encodedICS = base64Encode(ics);
 


### PR DESCRIPTION
- added `getReminder` to the DB
- moved some functions from `ws_send_ical` to `utils` for reusability 
- added support for multiple mail recipients 
- added logic for reminder and error mails in `ws_expirer`
