### PR TITLE
fix ws_list -L allocatable/extendable/restorable

### DIFF
--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -325,10 +325,11 @@ int main(int argc, char** argv) {
                      "keeptime", "allocatable", "extendable", "restorable", "comment");
         for (auto fs : config.validFilesystems(username, grouplist, ws::LIST)) {
             auto fsc = config.getFsConfig(fs);
+            bool allocateable = config.hasAccess(username, grouplist, fs, ws::CREATE) && fsc.allocatable;
+            bool extendable = config.hasAccess(username, grouplist, fs, ws::EXTEND) && fsc.extendable;
+            bool restorable = config.hasAccess(username, grouplist, fs, ws::RESTORE) && fsc.restorable;
             fmt::print("{:>10}{:>12}{:>12}{:>10}{:>12}{:>12}{:>12}   {}\n", fs, fsc.maxduration, fsc.maxextensions,
-                       fsc.keeptime, config.hasAccess(username, grouplist, fs, ws::CREATE),
-                       config.hasAccess(username, grouplist, fs, ws::EXTEND),
-                       config.hasAccess(username, grouplist, fs, ws::RESTORE), fsc.comment);
+                       fsc.keeptime, allocateable, extendable, restorable, fsc.comment);
         }
 
         if (verbose) {


### PR DESCRIPTION
- now checks if attributes are set to false in the config file

( At first I thought the problem was the config::hasAccess function, but turns out in other tool like `ws_allocate` we also check independently if allocatable, extendable and restorable are set. To my mind it would be worth discussing if a check of these attributes should be part of config::hasAccess ) 