### PR TITLE
Option consistency for -u & -g 

### DIFF
--- a/bats/test/ws_list.bats
+++ b/bats/test/ws_list.bats
@@ -188,7 +188,7 @@ Options:
   -l [ --listfilesystems ]        list available filesystems
   -L [ --listfilesystemdetails ]  list available filesystems with details
   -s [ --short ]                  short listing, only workspace names
-  -u [ --user ] arg               only show workspaces for selected user
+  -u [ --username ] arg           only show workspaces for selected user
   -e [ --expired ]                show expired workspaces
   -N [ --name ]                   sort by name
   -C [ --creation ]               sort by creation date
@@ -295,7 +295,7 @@ Options:
     run ws_list --config bats/ws.conf fsname
     assert_output --partial "filesystem name"
     assert_success
-    ws_release --config bats/ws.conf fsname
+    ws_release --config bats/ws.conf fsname 
 }
 
 @test "ws_list shows available extensions" {

--- a/bats/test/ws_list.bats
+++ b/bats/test/ws_list.bats
@@ -184,7 +184,7 @@ Options:
   -h [ --help ]                   produce help message
   -V [ --version ]                show version
   -F [ --filesystem ] arg         filesystem to list workspaces from
-  -g [ --group ]                  enable listing of group workspaces
+  -g [ --groupname ]              enable listing of group workspaces
   -l [ --listfilesystems ]        list available filesystems
   -L [ --listfilesystemdetails ]  list available filesystems with details
   -s [ --short ]                  short listing, only workspace names

--- a/src/ws_editdb.cpp
+++ b/src/ws_editdb.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
         ("help,h", "produce help message")
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to list workspaces from")
-        ("user,u", po::value<string>(&user), "only show workspaces for selected user")
+        ("username,u", po::value<string>(&user), "only show workspaces for selected user")
         ("expired,e", "show expired workspaces")
         ("config", po::value<string>(&configfile), "config file")
         ("pattern,p", po::value<string>(&pattern), "pattern matching name (glob syntax)")

--- a/src/ws_find.cpp
+++ b/src/ws_find.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to search workspaces in")
         ("group,g", "enable search for group workspaces")
-        ("user,u", po::value<string>(&user), "only show workspaces for selected user")
+        ("username,u", po::value<string>(&user), "only show workspaces for selected user")
         ("name,n", po::value<string>(&name), "workspace name to search for")
         ("config", po::value<string>(&configfile), "config file");
     // clang-format on

--- a/src/ws_find.cpp
+++ b/src/ws_find.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
         ("help,h", "produce help message")
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to search workspaces in")
-        ("group,g", "enable search for group workspaces")
+        ("groupname,g", "enable search for group workspaces")
         ("username,u", po::value<string>(&user), "only show workspaces for selected user")
         ("name,n", po::value<string>(&name), "workspace name to search for")
         ("config", po::value<string>(&configfile), "config file");

--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
         ("help,h", "produce help message")
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to list workspaces from")
-        ("group,g", "enable listing of group workspaces")
+        ("groupname,g", "enable listing of group workspaces")
         ("listfilesystems,l", "list available filesystems")
         ("listfilesystemdetails,L", "list available filesystems with details")
         ("short,s", "short listing, only workspace names")

--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -212,7 +212,7 @@ int main(int argc, char** argv) {
         ("listfilesystems,l", "list available filesystems")
         ("listfilesystemdetails,L", "list available filesystems with details")
         ("short,s", "short listing, only workspace names")
-        ("user,u", po::value<string>(&user), "only show workspaces for selected user")
+        ("username,u", po::value<string>(&user), "only show workspaces for selected user")
         ("expired,e", "show expired workspaces")
         ("name,N", "sort by name")
         ("creation,C", "sort by creation date")

--- a/src/ws_stat.cpp
+++ b/src/ws_stat.cpp
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
         ("help,h", "produce help message")
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to list workspaces from")
-        ("user,u", po::value<string>(&user), "only show workspaces for selected user")
+        ("username,u", po::value<string>(&user), "only show workspaces for selected user")
         ("group,g", "enable listing of group workspaces")
         ("config", po::value<string>(&configfile), "config file")
         ("pattern,p", po::value<string>(&pattern), "pattern matching name (glob syntax)")

--- a/src/ws_stat.cpp
+++ b/src/ws_stat.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to list workspaces from")
         ("username,u", po::value<string>(&user), "only show workspaces for selected user")
-        ("group,g", "enable listing of group workspaces")
+        ("groupname,g", "enable listing of group workspaces")
         ("config", po::value<string>(&configfile), "config file")
         ("pattern,p", po::value<string>(&pattern), "pattern matching name (glob syntax)")
         ("name,N", "sort by name")


### PR DESCRIPTION
Changed the options -u and -g to match each other and be consistent:
+ --group is now --groupname
+ --user is now --username 