### PR TITLE
Consistency Update for options

### DIFF
--- a/bats/test/ws_register.bats
+++ b/bats/test/ws_register.bats
@@ -110,10 +110,10 @@ teardown() {
 
 @test "ws_register with config file option" {
     ws_allocate --config bats/ws.conf -F ws1 CONFIGTEST
-    run ws_register -c bats/ws.conf $register_dir
+    run ws_register --config bats/ws.conf $register_dir
     assert_success
     assert_link_exists $register_dir/ws1/*-CONFIGTEST
-    ws_release -c bats/ws.conf -F ws1 CONFIGTEST
+    ws_release --config bats/ws.conf -F ws1 CONFIGTEST
 }
 
 @test "ws_register symlink points to correct workspace" {

--- a/bats/test/ws_release.bats
+++ b/bats/test/ws_release.bats
@@ -200,13 +200,6 @@ setup() {
     assert_success
 }
 
-@test "ws_release config file short form" {
-    ws_allocate --config bats/ws.conf -F ws1 configshort
-    run ws_release -c bats/ws.conf -F ws1 configshort
-    assert_output --partial "workspace configshort released"
-    assert_success
-}
-
 @test "ws_release name argument short form" {
     ws_allocate --config bats/ws.conf -F ws1 nameshort
     run ws_release --config bats/ws.conf -F ws1 -n nameshort

--- a/man/man1/ws_release.1
+++ b/man/man1/ws_release.1
@@ -78,7 +78,7 @@ delete all data in the workspace immediately. The workspace
 after this. There is a 5-second grace period during which the operation can be
 interrupted with CTRL-C. Use with care.
 .TP
-\-c, \-\-config CONFIGFILE
+\-\-config CONFIGFILE
 path to configfile, for root only or for unprivileged installations.
 
 .SH EXAMPLES

--- a/man/man1/ws_restore.1
+++ b/man/man1/ws_restore.1
@@ -104,7 +104,7 @@ The workspace
 after this. There is a 5-second grace period during which the operation can be
 interrupted with CTRL-C. Use with care.
 .TP
-\-c, \-\-config CONFIGFILE
+\-\-config CONFIGFILE
 path to configfile, for root only or for unprivileged installations.
 
 .SH EXAMPLES

--- a/man/man1/ws_send_ical.1
+++ b/man/man1/ws_send_ical.1
@@ -53,7 +53,7 @@ See
 .B ws_list \-l
 for a list of available filesystems.
 .TP
-\-n, \-\-workspace NAMEq
+\-n, \-\-name NAME
 name of the workspace to send the calendar entry for. Can also be given as the first
 positional argument.
 .TP

--- a/man/man8/ws_expirer.8
+++ b/man/man8/ws_expirer.8
@@ -5,7 +5,7 @@ ws_expirer \- expire and delete workspaces, intended to be run from a cronjob
 
 .SH SYNOPSIS
 .B ws_expirer
-[\-h] [\-V] [\-F FILESYSTEMS] [\-s SINGLE_SPACE] [\-c] [\-\-configfile CONFIGFILE]
+[\-h] [\-V] [\-F FILESYSTEMS] [\-s SINGLE_SPACE] [\-c] [\-\-config CONFIGFILE]
 
 .SH DESCRIPTION
 .B ws_expirer
@@ -65,7 +65,7 @@ process only the specified workspace space (path of a single space directory).
 \-c, \-\-cleaner
 enable cleaner mode: actually perform deletions instead of dry-run.
 .TP
-\-\-configfile CONFIGFILE
+\-\-config CONFIGFILE
 path to config file (default: \fI/etc/ws.d\fR, \fI/etc/ws.conf\fR).
 
 .SH OPERATION MODES

--- a/src/ws_expirer.cpp
+++ b/src/ws_expirer.cpp
@@ -714,7 +714,7 @@ int main(int argc, char** argv) {
         ("filesystems,F", po::value<string>(&filesystem), "filesystems/workspaces to delete from, comma separated")
         ("space,s", po::value<string>(&single_space), "path of a single space that should be deleted")
         ("cleaner,c", "no dry-run mode")
-        ("configfile", po::value<string>(&configfile), "path to configfile");
+        ("config", po::value<string>(&configfile), "path to configfile");
     // clang-format on
 
     po::options_description secret_options("Secret");

--- a/src/ws_register.cpp
+++ b/src/ws_register.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
         ("version,V", "show version")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem to list workspaces from")
         ("directory,d", po::value<string>(&directory), "target directory")
-        ("configfile,c", po::value<string>(&configfile), "path to configfile");
+        ("config", po::value<string>(&configfile), "path to configfile");
     // clang-format on
 
     po::options_description secret_options("Secret");

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -84,7 +84,7 @@ void commandline(po::variables_map& opt, string& name, string& filesystem, strin
         ("name,n", po::value<string>(&name), "workspace name")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem")
         ("username,u", po::value<string>(&user), "username")
-        ("config,c", po::value<string>(&configfile), "config file")
+        ("config", po::value<string>(&configfile), "config file")
         ("delete-data", "delete all data, workspace can NOT BE RECOVERED!");
     // clang-format on
 

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -81,7 +81,7 @@ void commandline(po::variables_map& opt, string& name, string& target, string& f
         ("name,n", po::value<string>(&name), "workspace name")
         ("target,t", po::value<string>(&target), "existing target workspace name")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem")
-        ("config,c", po::value<string>(&configfile), "config file")
+        ("config", po::value<string>(&configfile), "config file")
         ("username,u", po::value<string>(&username), "username")
         ("delete-data", "delete all data, workspace can NOT BE RECOVERED!");
     // clang-format on

--- a/src/ws_send_ical.cpp
+++ b/src/ws_send_ical.cpp
@@ -76,7 +76,7 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
         ("help,h", "produce help message")
         ("filesystem,F", po::value<string>(&filesystem), "filesystem where the workspace is located in")
         ("mail,m", po::value<string>(&mailaddress), "your mail address to send to")
-        ("workspace,n", po::value<string>(&name), "name of selected workspace")
+        ("name,n", po::value<string>(&name), "name of selected workspace")
         ("config", po::value<string>(&configfile), "config file");
     // clang-format on
 
@@ -85,7 +85,7 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
 
     // define options without names
     po::positional_options_description p;
-    p.add("workspace", 1);
+    p.add("name", 1);
     p.add("mail", 2);
 
     po::options_description all_options;
@@ -97,7 +97,7 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
         po::notify(opt);
     } catch (...) {
         fmt::println(stderr,
-                     "Usage: {} [-F filesystem | --filesystem filesystem] [-n|--workspace] workspacename [-m | --mail] "
+                     "Usage: {} [-F filesystem | --filesystem filesystem] [-n|--name] workspace_name [-m | --mail] "
                      "mailadress",
                      argv[0]);
         fmt::println(stderr, "{}", cmd_options);
@@ -108,7 +108,7 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
     if (opt.count("help")) {
         fmt::println(
             stderr,
-            "Usage: [-F filesystem | --filesystem filesystem] [-n|--workspace] workspacename [-m | --mail] mailadress",
+            "Usage: [-F filesystem | --filesystem filesystem] [-n|--name] workspace_name [-m | --mail] mailadress",
             argv[0]);
         fmt::println(stderr, "{}", cmd_options);
         fmt::println(stderr, "this command is used to send a calendar invitation by Email to ensure users do not "
@@ -134,7 +134,7 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
 
     // check if Workspace name is correctly formatted
     static const regex e("^[[:alnum:]][[:alnum:]_.-]*$");
-    if (opt.count("workspace") && regex_match(name, e)) {
+    if (opt.count("name") && regex_match(name, e)) {
         // check if mail option is present and evaluate
         if (!opt.count("mail")) {
             mailaddress = userconfig.getMailaddress();
@@ -152,14 +152,14 @@ void commandline(po::variables_map& opt, string& filesystem, string& mailaddress
             }
         }
     } else {
-        if (opt.count("workspace")) {
+        if (opt.count("name")) {
             spdlog::error("Illegal workspace name, use ASCII characters and numbers, '-','.' and '_' only!");
         } else {
             spdlog::error("no workspace name!");
         }
         fmt::println(
             stderr,
-            "Usage: [-F filesystem | --filesystem filesystem] [-n|--workspace] workspacename [-m | --mail] mailadress",
+            "Usage: [-F filesystem | --filesystem filesystem] [-n|--name] workspace_name [-m | --mail] mailadress",
             argv[0]);
         fmt::println(stderr, "{}", cmd_options);
         fmt::println(stderr, "this command is used to send a calendar invitation by Email to ensure users do not "

--- a/src/ws_stat.cpp
+++ b/src/ws_stat.cpp
@@ -362,8 +362,7 @@ int main(int argc, char** argv) {
     }
 
     // get flags
-
-    listgroups = opts.count("group");
+    listgroups = opts.count("groupname");
     verbose = opts.count("verbose");
     sortbyname = opts.count("name");
     sortbycreation = opts.count("creation");


### PR DESCRIPTION
As promised a consistency update for user options.
+ Changed `--configfile` to `--config`
+ Removed `-c` for some config options
+ Renamed `--workspace` to `--name` in `ws_send_ical
+ Updated man pages 