### PR TITLE
ws_expirer fix for compatibility with v1

### DIFF
--- a/src/ws_expirer.cpp
+++ b/src/ws_expirer.cpp
@@ -719,6 +719,10 @@ static expire_result_t expire_workspaces(const Config& config, const string fs, 
                              (releasetime + releasekeeptime * 24 * 3600)); // SPEC: releaskeeptime now also in days
         } else {
             // Expired, use keeptime
+            // Compatability with v1 --> expired is 0 so expiration get chosen, but for v1 db entries we need the releasetime from the filename 
+            if (dbentry->getExpired()==0) {
+                expiration = std::max(expiration, releasetime);
+            }
             should_delete = (time((long*)0L) > (expiration + keeptime * 24 * 3600));
         }
 

--- a/src/ws_expirer.cpp
+++ b/src/ws_expirer.cpp
@@ -719,8 +719,9 @@ static expire_result_t expire_workspaces(const Config& config, const string fs, 
                              (releasetime + releasekeeptime * 24 * 3600)); // SPEC: releaskeeptime now also in days
         } else {
             // Expired, use keeptime
-            // Compatability with v1 --> expired is 0 so expiration get chosen, but for v1 db entries we need the releasetime from the filename 
-            if (dbentry->getExpired()==0) {
+            // Compatability with v1 --> expired is 0 so expiration get chosen, but for v1 db entries we need the
+            // releasetime from the filename
+            if (dbentry->getExpired() == 0) {
                 expiration = std::max(expiration, releasetime);
             }
             should_delete = (time((long*)0L) > (expiration + keeptime * 24 * 3600));
@@ -956,8 +957,8 @@ int main(int argc, char** argv) {
                            "", result.valid_deleted, result.invalid_deleted));
     }
     append(fmt::format("  {:->84}", ""));
-    append(fmt::format("  {:<15} {:>7} {:>5} {:>7} {:>27} {:>5} {:>7}", "total", "", total_stray.valid_ws, total_stray.invalid_ws,
-                           "", total_stray.valid_deleted, total_stray.invalid_deleted));
+    append(fmt::format("  {:<15} {:>7} {:>5} {:>7} {:>27} {:>5} {:>7}", "total", "", total_stray.valid_ws,
+                       total_stray.invalid_ws, "", total_stray.valid_deleted, total_stray.invalid_deleted));
     append("");
     append("Expiration Summary");
     append("");
@@ -971,8 +972,9 @@ int main(int argc, char** argv) {
     }
     append(fmt::format("  {:->84}", ""));
     append(fmt::format("  {:<15} {:>7} {:>4} {:>4} {:>7} {:>5} {:>17} {:>4} {:>4} {:>7}", "total", "",
-                           total_expire.active_seen, total_expire.active_keep, total_expire.active_expired, total_expire.active_mails, "",
-                           total_expire.inactive_seen, total_expire.inactive_keep, total_expire.inactive_deleted));
+                       total_expire.active_seen, total_expire.active_keep, total_expire.active_expired,
+                       total_expire.active_mails, "", total_expire.inactive_seen, total_expire.inactive_keep,
+                       total_expire.inactive_deleted));
     if (morbid_db_files.count != 0) {
         append("");
         append(" Morbid DB Files");

--- a/src/ws_list.cpp
+++ b/src/ws_list.cpp
@@ -90,9 +90,9 @@ static string getMaskedID(const DBEntry* entry) {
 template <> struct fmt::formatter<po::options_description> : ostream_formatter {};
 
 // print entry in traditional format, one below each other, multiline
-void print_entry(const DBEntry* entry, const Config config ,const bool verbose, const bool terse, const bool permissions, const bool listexpired) {
+void print_entry(const DBEntry* entry, const Config config, const bool verbose, const bool terse,
+                 const bool permissions, const bool listexpired) {
     lock_guard<mutex> lock(print_entry_mtx);
-
 
     fmt::println("Id: {}", getMaskedID(entry));
 
@@ -101,30 +101,31 @@ void print_entry(const DBEntry* entry, const Config config ,const bool verbose, 
     auto fs = entry->getFilesystem();
     auto fsconfig = config.getFsConfig(fs);
 
-    if (!listexpired){
+    if (!listexpired) {
         remaining = entry->getRemaining();
         fmt::println("    remaining time       : {} days, {} hours", remaining / (24 * 3600),
                      (remaining % (24 * 3600)) / 3600);
     } else {
-        if (entry->getReleaseTime() != 0){
+        if (entry->getReleaseTime() != 0) {
             fmt::println("    remaining time       : {}", "released");
-            remaining = (entry->getReleaseTime()+(fsconfig.releasekeeptime*86400))-time(0L);
+            remaining = (entry->getReleaseTime() + (fsconfig.releasekeeptime * 86400)) - time(0L);
         } else {
             fmt::println("    remaining time       : {}", "expired");
-            remaining = (entry->getExpired()+(fsconfig.keeptime*86400)) - time(0L);
-            if (remaining == 0){ // compatability with v1 --> get expiration from the name if expired is not defined 
+            remaining = (entry->getExpired() + (fsconfig.keeptime * 86400)) - time(0L);
+            if (remaining == 0) { // compatability with v1 --> get expiration from the name if expired is not defined
                 std::string id = entry->getId();
-                remaining = (std::stol(utils::splitString(id, '-').at(std::count(id.begin(), id.end(), '-')))+(fsconfig.keeptime*86400)) - time(0L);
+                remaining = (std::stol(utils::splitString(id, '-').at(std::count(id.begin(), id.end(), '-'))) +
+                             (fsconfig.keeptime * 86400)) -
+                            time(0L);
             }
         }
 
-        if (remaining <= 0){
+        if (remaining <= 0) {
             fmt::println("    until deletion       : 0 days, 0 hours");
         } else {
             fmt::println("    until deletion       : {} days, {} hours", remaining / (24 * 3600),
-                        (remaining % (24 * 3600)) / 3600);
+                         (remaining % (24 * 3600)) / 3600);
         }
-
     }
 
     if (!terse) {
@@ -155,8 +156,8 @@ void print_entry(const DBEntry* entry, const Config config ,const bool verbose, 
     }
 }
 
-void print_entry_tableformat(const DBEntry* entry, const Config config, [[maybe_unused]] const bool verbose, const bool terse, 
-                             [[maybe_unused]] const bool permissions, const bool listexpired) {
+void print_entry_tableformat(const DBEntry* entry, const Config config, [[maybe_unused]] const bool verbose,
+                             const bool terse, [[maybe_unused]] const bool permissions, const bool listexpired) {
     static bool headerprinted = false;
     static bool color_checked = false;
     static bool color_output = true;
@@ -166,16 +167,18 @@ void print_entry_tableformat(const DBEntry* entry, const Config config, [[maybe_
     auto fs = entry->getFilesystem();
     auto fsconfig = config.getFsConfig(fs);
 
-    if (!listexpired){
+    if (!listexpired) {
         remaining = entry->getRemaining();
     } else {
-        if (entry->getReleaseTime() != 0){
-            remaining = (entry->getReleaseTime()+(fsconfig.releasekeeptime*86400))-time(0L);
+        if (entry->getReleaseTime() != 0) {
+            remaining = (entry->getReleaseTime() + (fsconfig.releasekeeptime * 86400)) - time(0L);
         } else {
-            remaining = (entry->getExpired()+(fsconfig.keeptime*86400)) - time(0L);
-            if (remaining == 0){ // compatability with v1 --> get expiration from the name if expired is not defined 
+            remaining = (entry->getExpired() + (fsconfig.keeptime * 86400)) - time(0L);
+            if (remaining == 0) { // compatability with v1 --> get expiration from the name if expired is not defined
                 std::string id = entry->getId();
-                remaining = (std::stol(utils::splitString(id, '-').at(std::count(id.begin(), id.end(), '-')))+(fsconfig.keeptime*86400)) - time(0L);
+                remaining = (std::stol(utils::splitString(id, '-').at(std::count(id.begin(), id.end(), '-'))) +
+                             (fsconfig.keeptime * 86400)) -
+                            time(0L);
             }
         }
     }
@@ -228,22 +231,24 @@ void print_entry_tableformat(const DBEntry* entry, const Config config, [[maybe_
 
     if (terse) {
         if (color_output)
-            fmt::println("{:<30}{} {:<50}{} {:<9}", ID, ID.length()>30 ? fmt::format("{:31}","\n") : "",
-			 entry->getWSPath(), entry->getWSPath().length()>50 ? fmt::format("{:82}","\n") : "",
+            fmt::println("{:<30}{} {:<50}{} {:<9}", ID, ID.length() > 30 ? fmt::format("{:31}", "\n") : "",
+                         entry->getWSPath(), entry->getWSPath().length() > 50 ? fmt::format("{:82}", "\n") : "",
                          fmt::styled(remaining / (24 * 3600), fg(remaincolor)));
         else
-            fmt::println("{:<30}{} {:<50}{} {:<9}", ID, ID.length()>30 ? fmt::format("{:31}","\n") : "",
-			 entry->getWSPath(), entry->getWSPath().length()>50 ? fmt::format("{:82}","\n") : "",
-			 remaining / (24 * 3600));
+            fmt::println("{:<30}{} {:<50}{} {:<9}", ID, ID.length() > 30 ? fmt::format("{:31}", "\n") : "",
+                         entry->getWSPath(), entry->getWSPath().length() > 50 ? fmt::format("{:82}", "\n") : "",
+                         remaining / (24 * 3600));
     } else {
         if (color_output)
-            fmt::println("{:<30}{} {:<50}{} {:<25} {:<10} {:<9}", ID, ID.length()>30 ? fmt::format("{:31}","\n") : "",
-			 entry->getWSPath(), entry->getWSPath().length()>50 ? fmt::format("{:82}","\n") : "",
+            fmt::println("{:<30}{} {:<50}{} {:<25} {:<10} {:<9}", ID,
+                         ID.length() > 30 ? fmt::format("{:31}", "\n") : "", entry->getWSPath(),
+                         entry->getWSPath().length() > 50 ? fmt::format("{:82}", "\n") : "",
                          utils::ctime(entry->getExpiration()), entry->getExtension(),
                          fmt::styled(remaining / (24 * 3600), fg(remaincolor)));
-        else 
-            fmt::println("{:<30}{} {:<50}{} {:<25} {:<10} {:<9}", ID, ID.length()>30 ? fmt::format("{:31}","\n") : "",
-			 entry->getWSPath(), entry->getWSPath().length()>50 ? fmt::format("{:82}","\n") : "",
+        else
+            fmt::println("{:<30}{} {:<50}{} {:<25} {:<10} {:<9}", ID,
+                         ID.length() > 30 ? fmt::format("{:31}", "\n") : "", entry->getWSPath(),
+                         entry->getWSPath().length() > 50 ? fmt::format("{:82}", "\n") : "",
                          utils::ctime(entry->getExpiration()), entry->getExtension(), remaining / (24 * 3600));
     }
 #pragma GCC diagnostic pop
@@ -520,10 +525,12 @@ int main(int argc, char** argv) {
                                                      fmt::println("{}", getMaskedID(entry.get()));
                                                  } else {
                                                      if (!tableformat)
-                                                         print_entry(entry.get(), config, verbose, terselisting, permissions, listexpired);
+                                                         print_entry(entry.get(), config, verbose, terselisting,
+                                                                     permissions, listexpired);
                                                      else
-                                                         print_entry_tableformat(entry.get(), config, verbose, terselisting,
-                                                                                 permissions, listexpired);
+                                                         print_entry_tableformat(entry.get(), config, verbose,
+                                                                                 terselisting, permissions,
+                                                                                 listexpired);
                                                  }
                                              }
                                          }

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -314,14 +314,15 @@ bool release(const Config& config, const po::variables_map& opt, string filesyst
                 spdlog::info("cross device rename, falling back to 'mv'");
                 int ret = utils::mv(dbentry->getWSPath().c_str(), target.c_str());
                 caps.lower_cap({CAP_DAC_OVERRIDE}, dbentry->getConfig()->dbuid(),
-                            utils::SrcPos(__FILE__, __LINE__, __func__));
+                               utils::SrcPos(__FILE__, __LINE__, __func__));
                 if (ret != 0) {
-                    spdlog::error("workspace directory could not be moved to deleted path via 'mv': {}", strerror(errno));
+                    spdlog::error("workspace directory could not be moved to deleted path via 'mv': {}",
+                                  strerror(errno));
                     return false;
                 }
             } else {
                 caps.lower_cap({CAP_DAC_OVERRIDE}, dbentry->getConfig()->dbuid(),
-                            utils::SrcPos(__FILE__, __LINE__, __func__));
+                               utils::SrcPos(__FILE__, __LINE__, __func__));
                 if (debugflag)
                     spdlog::error("{}", e.what());
                 spdlog::error("workspace directory could not be moved to deleted path!");

--- a/src/ws_validate_config.cpp
+++ b/src/ws_validate_config.cpp
@@ -274,7 +274,8 @@ int main(int argc, char** argv) {
                 }
                 if (stat(space.c_str(), &sb) == 0) {
                     if (sb.st_uid != dbuid || sb.st_gid != dbgid) {
-                        spdlog::warn("spaces path {} has incorrect ownership (expected {}:{}, got {}:{})", space, dbuid, dbgid, sb.st_uid, sb.st_gid);
+                        spdlog::warn("spaces path {} has incorrect ownership (expected {}:{}, got {}:{})", space, dbuid,
+                                     dbgid, sb.st_uid, sb.st_gid);
                     }
                 }
                 perms = cppfs::status(deletedpath).permissions();
@@ -283,7 +284,9 @@ int main(int argc, char** argv) {
                 }
                 if (stat(deletedpath.c_str(), &sb) == 0) {
                     if (sb.st_uid != dbuid || sb.st_gid != dbgid) {
-                        spdlog::warn("deleted directory {} in space {} has incorrect ownership (expected {}:{}, got {}:{})", deleted, space, dbuid, dbgid, sb.st_uid, sb.st_gid);
+                        spdlog::warn(
+                            "deleted directory {} in space {} has incorrect ownership (expected {}:{}, got {}:{})",
+                            deleted, space, dbuid, dbgid, sb.st_uid, sb.st_gid);
                     }
                 }
             }
@@ -324,7 +327,8 @@ int main(int argc, char** argv) {
             }
             if (stat(database.c_str(), &sb) == 0) {
                 if (sb.st_uid != dbuid || sb.st_gid != dbgid) {
-                    spdlog::warn("database path {} has incorrect ownership (expected {}:{}, got {}:{})", database, dbuid, dbgid, sb.st_uid, sb.st_gid);
+                    spdlog::warn("database path {} has incorrect ownership (expected {}:{}, got {}:{})", database,
+                                 dbuid, dbgid, sb.st_uid, sb.st_gid);
                 }
             }
             perms = cppfs::status(wsdbmagicpath).permissions();
@@ -333,7 +337,9 @@ int main(int argc, char** argv) {
             }
             if (stat(wsdbmagicpath.c_str(), &sb) == 0) {
                 if (sb.st_uid != dbuid || sb.st_gid != dbgid) {
-                    spdlog::warn(".ws_db_magic in database directory {} has incorrect ownership (expected {}:{}, got {}:{})", database, dbuid, dbgid, sb.st_uid, sb.st_gid);
+                    spdlog::warn(
+                        ".ws_db_magic in database directory {} has incorrect ownership (expected {}:{}, got {}:{})",
+                        database, dbuid, dbgid, sb.st_uid, sb.st_gid);
                 }
             }
             perms = cppfs::status(deletedpath).permissions();
@@ -342,7 +348,9 @@ int main(int argc, char** argv) {
             }
             if (stat(deletedpath.c_str(), &sb) == 0) {
                 if (sb.st_uid != dbuid || sb.st_gid != dbgid) {
-                    spdlog::warn("deleted directory {} in database {} has incorrect ownership (expected {}:{}, got {}:{})", deleted, database, dbuid, dbgid, sb.st_uid, sb.st_gid);
+                    spdlog::warn(
+                        "deleted directory {} in database {} has incorrect ownership (expected {}:{}, got {}:{})",
+                        deleted, database, dbuid, dbgid, sb.st_uid, sb.st_gid);
                 }
             }
         } else {


### PR DESCRIPTION
- little fix to ensure compatibility with v1 noticed during testing on cara 
- since `dbentry→getExpired()` is 0 for v1 db entries, expiration get chosen, but we need the releasetime from the filename otherwise we might delete too early 

+ clang-format 